### PR TITLE
【杂项】将 Linter 和 Formatter 迁移到 Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 120
-extend-select = B950
-extend-ignore = E203,E501,E701

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest-large]
+        os: [windows-latest, ubuntu-latest]
 
       fail-fast: false
 
@@ -158,7 +158,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest-xlarge]
+        os: [macos-latest]
 
       fail-fast: false
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu, macos, windows]
+        include:
+          - os: windows-latest
+            arch: x86
+          - os: [windows-latest, macos-latest-large, ubuntu-latest]
+            arch: x64
+          - os: macos-latest-xlarge
+            arch: arm64
       fail-fast: false
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: 检出仓库
@@ -33,7 +39,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: 3.11
-          architecture: x64
+          architecture: ${{ matrix.arch }}
           cache: true
       - name: 安装依赖项和提交钩子
         run: |-
@@ -45,8 +51,8 @@ jobs:
           echo "::endgroup::"
       - name: 执行持续集成检查
         run: pdm run ci
-        continue-on-error: true
         env:
+          # 让 Ruff 以 GitHub Workflows 集成格式进行输出
           RUFF_OUTPUT_FORMAT: github
       - name: 编译打包
         # macOS 的图标使用 *.icns 而非 *.ico
@@ -57,7 +63,7 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/')
         uses: actions/upload-artifact@v4
         with:
-          name: Numzle-${{ matrix.os }}_amd64
+          name: Numzle-${{ matrix.os }}_${{ matrix.arch }}
           path: dist/Numzle*
           retention-days: 7
       - name: 生成发布说明

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,18 +7,13 @@ on:
   push:
 
 jobs:
-  build:
+  amd64:
     name: 编译构建（${{ matrix.os }} amd64）
 
     strategy:
       matrix:
-        include:
-          - os: windows-latest
-            arch: x86
-          - os: [windows-latest, macos-latest-large, ubuntu-latest]
-            arch: x64
-          - os: macos-latest-xlarge
-            arch: arm64
+        os: [windows-latest, ubuntu-latest, macos-latest-large]
+
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -34,12 +29,88 @@ jobs:
         uses: seanmiddleditch/gha-setup-vsdevenv@v4
         with:
           arch: amd64
-          host_arch: amd64
       - name: 配置 PDM 构建环境
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: 3.11
-          architecture: ${{ matrix.arch }}
+          architecture: x64
+          cache: true
+      - name: 安装依赖项和提交钩子
+        run: |-
+          echo "::group::安装依赖项"
+          pdm install
+          echo "::endgroup::"
+          echo "::group::安装提交钩子"
+          pdm run git
+          echo "::endgroup::"
+      - name: 执行持续集成检查
+        run: pdm run ci
+        env:
+          # 让 Ruff 以 GitHub Workflows 集成格式进行输出
+          RUFF_OUTPUT_FORMAT: github
+      - name: 获取系统代号
+        id: get_os
+        run: |-
+          if [[ "${{ matrix.os }}" =~ "windows" ]]; then
+            echo "os=windows" >> "$GITHUB_OUTPUT";
+          elif [[ "${{ matrix.os }}" =~ "macos" ]]; then
+            echo "os=darwin" >> "$GITHUB_OUTPUT";
+          elif [[ "${{ matrix.os }}" =~ "ubuntu" ]]; then
+            echo "os=linux" >> "$GITHUB_OUTPUT";
+          fi
+      - name: 编译打包
+        # macOS 的图标使用 *.icns 而非 *.ico
+        # 因此 Dev Dependencies 中的 Pillow 是必要的
+        # PyInstaller 会使用它转换图标格式
+        run: pdm run build "Numzle-${{ steps.get_os.outputs.os }}_amd64"
+      - name: 发布每日构建
+        if: startsWith(github.ref, 'refs/heads/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: Numzle-${{ steps.get_os.outputs.os }}_amd64
+          path: dist/Numzle*
+          retention-days: 7
+      - name: 生成发布说明
+        id: changelog
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |-
+          git log -n 1 --pretty="format: ## %s%n%n%b" > CHANGELOG.txt
+      - name: 发布构建产物
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: CHANGELOG.txt
+          draft: true
+          prerelease: ${{ startsWith(github.ref_name, 'v0') }}
+          files: |-
+            dist/Numzle*
+
+  i386:
+    name: 编译构建（${{ matrix.os }} i386）
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: 检出仓库
+        uses: actions/checkout@v4
+      - name: 安装 MSVC
+        # Runner 模式预装 MinGW-w64 用于编译 NumPy
+        # 这还只是实验性质的功能，当 PyInstaller 打包时会崩溃
+        # 我们需要安装配置 MSVC ，让 PDM 用它去编译构建 NumPy
+        uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          arch: x86
+      - name: 配置 PDM 构建环境
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: 3.11
+          architecture: x86
           cache: true
       - name: 安装依赖项和提交钩子
         run: |-
@@ -58,12 +129,72 @@ jobs:
         # macOS 的图标使用 *.icns 而非 *.ico
         # 因此 Dev Dependencies 中的 Pillow 是必要的
         # PyInstaller 会使用它转换图标格式
-        run: pdm run build "Numzle-${{ matrix.os }}_amd64"
+        run: pdm run build "Numzle-windows_i386"
       - name: 发布每日构建
         if: startsWith(github.ref, 'refs/heads/')
         uses: actions/upload-artifact@v4
         with:
-          name: Numzle-${{ matrix.os }}_${{ matrix.arch }}
+          name: Numzle-windows_i386
+          path: dist/Numzle*
+          retention-days: 7
+      - name: 生成发布说明
+        id: changelog
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |-
+          git log -n 1 --pretty="format: ## %s%n%n%b" > CHANGELOG.txt
+      - name: 发布构建产物
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: CHANGELOG.txt
+          draft: true
+          prerelease: ${{ startsWith(github.ref_name, 'v0') }}
+          files: |-
+            dist/Numzle*
+
+  arm64:
+    name: 编译构建（${{ matrix.os }} arm64）
+
+    strategy:
+      matrix:
+        os: [macos-latest-xlarge]
+
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: 检出仓库
+        uses: actions/checkout@v4
+      - name: 配置 PDM 构建环境
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: 3.11
+          architecture: arm64
+          cache: true
+      - name: 安装依赖项和提交钩子
+        run: |-
+          echo "::group::安装依赖项"
+          pdm install
+          echo "::endgroup::"
+          echo "::group::安装提交钩子"
+          pdm run git
+          echo "::endgroup::"
+      - name: 执行持续集成检查
+        run: pdm run ci
+        env:
+          # 让 Ruff 以 GitHub Workflows 集成格式进行输出
+          RUFF_OUTPUT_FORMAT: github
+      - name: 编译打包
+        # macOS 的图标使用 *.icns 而非 *.ico
+        # 因此 Dev Dependencies 中的 Pillow 是必要的
+        # PyInstaller 会使用它转换图标格式
+        run: pdm run build "Numzle-darwin_arm64"
+      - name: 发布每日构建
+        if: startsWith(github.ref, 'refs/heads/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: Numzle-darwin_arm64
           path: dist/Numzle*
           retention-days: 7
       - name: 生成发布说明

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,9 @@ jobs:
           echo "::endgroup::"
       - name: 执行持续集成检查
         run: pdm run ci
+        continue-on-error: true
+        env:
+          RUFF_OUTPUT_FORMAT: github
       - name: 编译打包
         # macOS 的图标使用 *.icns 而非 *.ico
         # 因此 Dev Dependencies 中的 Pillow 是必要的

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,7 @@ jobs:
           RUFF_OUTPUT_FORMAT: github
       - name: 获取系统代号
         id: get_os
+        shell: bash
         run: |-
           if [[ "${{ matrix.os }}" =~ "windows" ]]; then
             echo "os=windows" >> "$GITHUB_OUTPUT";

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,12 @@
 repos:
-  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.1
     hooks:
-      - id: black
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.12
+      # Run the linter.
+      - id: ruff
         args:
-          - "--line-length=120"
+          - "--fix"
+          - "--verbose"
+      # Run the formatter.
+      - id: ruff-format

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:889d82e3674b13c9ecdaf34610c73ea8daca8f758796792f5f0bee323488deb6"
+content_hash = "sha256:57e47f33aa0c8f3aef8974c2fa302c874bc6b9cf82d82f7d52eca30c0582d086"
 
 [[package]]
 name = "altgraph"
@@ -18,39 +18,6 @@ files = [
 ]
 
 [[package]]
-name = "attrs"
-version = "23.2.0"
-requires_python = ">=3.7"
-summary = "Classes Without Boilerplate"
-groups = ["dev"]
-files = [
-    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
-    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
-]
-
-[[package]]
-name = "black"
-version = "24.4.0"
-requires_python = ">=3.8"
-summary = "The uncompromising code formatter."
-groups = ["dev"]
-dependencies = [
-    "click>=8.0.0",
-    "mypy-extensions>=0.4.3",
-    "packaging>=22.0",
-    "pathspec>=0.9.0",
-    "platformdirs>=2",
-]
-files = [
-    {file = "black-24.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8e5537f456a22cf5cfcb2707803431d2feeb82ab3748ade280d6ccd0b40ed2e8"},
-    {file = "black-24.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:64e60a7edd71fd542a10a9643bf369bfd2644de95ec71e86790b063aa02ff745"},
-    {file = "black-24.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cd5b4f76056cecce3e69b0d4c228326d2595f506797f40b9233424e2524c070"},
-    {file = "black-24.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:64578cf99b6b46a6301bc28bdb89f9d6f9b592b1c5837818a177c98525dbe397"},
-    {file = "black-24.4.0-py3-none-any.whl", hash = "sha256:74eb9b5420e26b42c00a3ff470dc0cd144b80a766128b1771d07643165e08d0e"},
-    {file = "black-24.4.0.tar.gz", hash = "sha256:f07b69fda20578367eaebbd670ff8fc653ab181e1ff95d84497f9fa20e7d0641"},
-]
-
-[[package]]
 name = "cfgv"
 version = "3.4.0"
 requires_python = ">=3.8"
@@ -59,32 +26,6 @@ groups = ["dev"]
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
-]
-
-[[package]]
-name = "click"
-version = "8.1.7"
-requires_python = ">=3.7"
-summary = "Composable command line interface toolkit"
-groups = ["dev"]
-dependencies = [
-    "colorama; platform_system == \"Windows\"",
-]
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[[package]]
-name = "colorama"
-version = "0.4.6"
-requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-summary = "Cross-platform colored terminal text."
-groups = ["dev"]
-marker = "platform_system == \"Windows\""
-files = [
-    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
-    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 
 [[package]]
@@ -109,37 +50,6 @@ files = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.0.0"
-requires_python = ">=3.8.1"
-summary = "the modular source code checker: pep8 pyflakes and co"
-groups = ["dev"]
-dependencies = [
-    "mccabe<0.8.0,>=0.7.0",
-    "pycodestyle<2.12.0,>=2.11.0",
-    "pyflakes<3.3.0,>=3.2.0",
-]
-files = [
-    {file = "flake8-7.0.0-py2.py3-none-any.whl", hash = "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"},
-    {file = "flake8-7.0.0.tar.gz", hash = "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132"},
-]
-
-[[package]]
-name = "flake8-bugbear"
-version = "24.2.6"
-requires_python = ">=3.8.1"
-summary = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
-groups = ["dev"]
-dependencies = [
-    "attrs>=19.2.0",
-    "flake8>=6.0.0",
-]
-files = [
-    {file = "flake8-bugbear-24.2.6.tar.gz", hash = "sha256:f9cb5f2a9e792dd80ff68e89a14c12eed8620af8b41a49d823b7a33064ac9658"},
-    {file = "flake8_bugbear-24.2.6-py3-none-any.whl", hash = "sha256:663ef5de80cd32aacd39d362212983bc4636435a6f83700b4ed35acbd0b7d1b8"},
-]
-
-[[package]]
 name = "identify"
 version = "2.5.35"
 requires_python = ">=3.8"
@@ -148,17 +58,6 @@ groups = ["dev"]
 files = [
     {file = "identify-2.5.35-py2.py3-none-any.whl", hash = "sha256:c4de0081837b211594f8e877a6b4fad7ca32bbfc1a9307fdd61c28bfe923f13e"},
     {file = "identify-2.5.35.tar.gz", hash = "sha256:10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791"},
-]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-requires_python = ">=3.8.0"
-summary = "A Python utility / library to sort Python imports."
-groups = ["dev"]
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
 ]
 
 [[package]]
@@ -173,17 +72,6 @@ dependencies = [
 files = [
     {file = "macholib-1.16.3-py2.py3-none-any.whl", hash = "sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c"},
     {file = "macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30"},
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-requires_python = ">=3.6"
-summary = "McCabe checker, plugin for flake8"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -264,17 +152,6 @@ files = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-requires_python = ">=3.8"
-summary = "Utility library for gitignore style pattern matching of file paths."
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "pefile"
 version = "2023.2.7"
 requires_python = ">=3.6.0"
@@ -351,28 +228,6 @@ files = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.11.1"
-requires_python = ">=3.8"
-summary = "Python style guide checker"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.2.0"
-requires_python = ">=3.8"
-summary = "passive checker of Python programs"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
-]
-
-[[package]]
 name = "pyinstaller"
 version = "6.6.0"
 requires_python = "<3.13,>=3.8"
@@ -445,6 +300,32 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
+name = "ruff"
+version = "0.4.1"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter and code formatter, written in Rust."
+groups = ["dev"]
+files = [
+    {file = "ruff-0.4.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2d9ef6231e3fbdc0b8c72404a1a0c46fd0dcea84efca83beb4681c318ea6a953"},
+    {file = "ruff-0.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9485f54a7189e6f7433e0058cf8581bee45c31a25cd69009d2a040d1bd4bfaef"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2921ac03ce1383e360e8a95442ffb0d757a6a7ddd9a5be68561a671e0e5807e"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eec8d185fe193ad053eda3a6be23069e0c8ba8c5d20bc5ace6e3b9e37d246d3f"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:baa27d9d72a94574d250f42b7640b3bd2edc4c58ac8ac2778a8c82374bb27984"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f1ee41580bff1a651339eb3337c20c12f4037f6110a36ae4a2d864c52e5ef954"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0926cefb57fc5fced629603fbd1a23d458b25418681d96823992ba975f050c2b"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c6e37f2e3cd74496a74af9a4fa67b547ab3ca137688c484749189bf3a686ceb"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efd703a5975ac1998c2cc5e9494e13b28f31e66c616b0a76e206de2562e0843c"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b92f03b4aa9fa23e1799b40f15f8b95cdc418782a567d6c43def65e1bbb7f1cf"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1c859f294f8633889e7d77de228b203eb0e9a03071b72b5989d89a0cf98ee262"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b34510141e393519a47f2d7b8216fec747ea1f2c81e85f076e9f2910588d4b64"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6e68d248ed688b9d69fd4d18737edcbb79c98b251bba5a2b031ce2470224bdf9"},
+    {file = "ruff-0.4.1-py3-none-win32.whl", hash = "sha256:b90506f3d6d1f41f43f9b7b5ff845aeefabed6d2494307bc7b178360a8805252"},
+    {file = "ruff-0.4.1-py3-none-win_amd64.whl", hash = "sha256:c7d391e5936af5c9e252743d767c564670dc3889aff460d35c518ee76e4b26d7"},
+    {file = "ruff-0.4.1-py3-none-win_arm64.whl", hash = "sha256:a1eaf03d87e6a7cd5e661d36d8c6e874693cb9bc3049d110bc9a97b350680c43"},
+    {file = "ruff-0.4.1.tar.gz", hash = "sha256:d592116cdbb65f8b1b7e2a2b48297eb865f6bdc20641879aa9d7b9c11d86db79"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ description = "Default template for PDM package"
 authors = [
     { name = "是蓝兔哟～", email = "49941141+Dragon1573@users.noreply.github.com" },
 ]
-dependencies = [
-    "numpy>=1.26.4",
-]
+dependencies = ["numpy>=1.26.4"]
 requires-python = ">=3.11,<3.12"
 readme = "README.md"
 license = { text = "AGPL-3.0" }
@@ -16,34 +14,26 @@ license = { text = "AGPL-3.0" }
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
 
-[tool.isort]
-profile = "black"
-
 [tool.pdm]
 distribution = false
 
 [tool.pdm.dev-dependencies]
 dev = [
-    "isort>=5.13.2",
-    "black>=24.4.0",
-    "flake8>=7.0.0",
-    "flake8-bugbear>=24.2.6",
     "mypy>=1.9.0",
     "pyinstaller>=6.6.0",
     "pre-commit>=3.7.0",
     "Pillow>=10.3.0",
+    "ruff>=0.4.1",
 ]
 
 [tool.pdm.scripts]
-isort.cmd = "python -m isort -v --profile=black ./src/"
-isort.help = "Sort all imports in the source code."
-black.cmd = "python -m black -v --line-length=120 ./src/"
-black.help = "Reformat the source code."
-flake8.cmd = "python -m flake8 -v ./src/"
-flake8.help = "Lint the source code."
+lint.cmd = "ruff check -v --fix ./src/"
+lint.help = "Lint the project with Ruff."
+format.cmd = "ruff format -v ./src/"
+format.help = "Reformat the project with Ruff and automatically fixup violations."
 mypy.cmd = "python -m mypy ./src/"
 mypy.help = "Scan source code with a static type checker."
-ci.composite = ["isort", "black", "flake8", "mypy"]
+ci.composite = ["lint", "format", "mypy"]
 ci.help = "Run a full CI of the project."
 play.cmd = "python src/main.py"
 play.help = "Launch the main application."
@@ -51,3 +41,10 @@ build.cmd = "pyinstaller --disable-windowed-traceback -y --clean -F -n {args} -w
 build.help = "Build a single-file executable of the project."
 git.cmd = "pre-commit install"
 git.help = "Install pre-commit hooks into Git repository."
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+extend-select = ["B9"]
+extend-ignore = ["E203", "E501", "E701"]


### PR DESCRIPTION
## 简介

_Ruff_ 是一个用 _Rust_ 开发而成的 Python 高性能 **静态代码分析** 和 **格式化** 工具，它一次性地重构并集成了 `isort` `black` `flake8` `flake8-bugbear` 的功能，让本项目的依赖可以尽可能简单。

- [官方简介](https://docs.astral.sh/ruff/)